### PR TITLE
Fix runtime errors and add placeholder pages

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Archive - Fable Exchange</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>📈 Fable Market Exchange</h1>
+    <nav>
+      <a href="index.html">Exchange</a> |
+      <a href="portfolio.html">Portfolio</a> |
+      <a href="npc.html">NPCs</a> |
+      <a href="archive.html" class="active">Archive</a>
+    </nav>
+  </header>
+  <main>
+    <h2>Archive</h2>
+    <p>Historical news archive coming soon.</p>
+  </main>
+</body>
+</html>

--- a/npc.html
+++ b/npc.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NPCs - Fable Exchange</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>📈 Fable Market Exchange</h1>
+    <nav>
+      <a href="index.html">Exchange</a> |
+      <a href="portfolio.html">Portfolio</a> |
+      <a href="npc.html" class="active">NPCs</a> |
+      <a href="archive.html">Archive</a>
+    </nav>
+  </header>
+  <main>
+    <h2>NPCs</h2>
+    <p>NPC directory coming soon.</p>
+  </main>
+</body>
+</html>

--- a/portfolio.js
+++ b/portfolio.js
@@ -32,12 +32,19 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function loadPortfolio() {
-    const saved = JSON.parse(localStorage.getItem("fablePortfolio")) || {};
-    return {
-      marks: saved.marks || 1000,
-      portfolio: saved.portfolio || {},
-      tradeHistory: saved.tradeHistory || []
-    };
+    try {
+      const raw = localStorage.getItem("fablePortfolio");
+      const saved = raw ? JSON.parse(raw) : {};
+      return {
+        marks: saved.marks || 1000,
+        portfolio: saved.portfolio || {},
+        tradeHistory: saved.tradeHistory || []
+      };
+    } catch (e) {
+      console.error("Failed to parse portfolio from localStorage", e);
+      localStorage.removeItem("fablePortfolio");
+      return { marks: 1000, portfolio: {}, tradeHistory: [] };
+    }
   }
 
   function formatMarks(val) {

--- a/script.js
+++ b/script.js
@@ -135,9 +135,18 @@ document.addEventListener("DOMContentLoaded", () => {
       for (let i = 0; i < 90; i++) {
         const change = current * (Math.random() * vol * 2 - vol);
         current = Math.max(1, current + change);
-        history.push(current.toFixed(2));
+        history.push(Number(current.toFixed(2)));
       }
       return history;
+    }
+
+    function updateDetailsPage(security) {
+      detailsPanel.innerHTML = `
+        <h3>${security.name} (${security.code})</h3>
+        <p>${security.desc}</p>
+        <p>Price: ${formatMarks(security.price)}</p>
+        <p>Volatility: ${security.volatility}</p>
+      `;
     }
 
     function trade(type) {
@@ -180,11 +189,16 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function loadPortfolio() {
-      const saved = JSON.parse(localStorage.getItem("fablePortfolio"));
-      if (saved) {
+      try {
+        const savedRaw = localStorage.getItem("fablePortfolio");
+        if (!savedRaw) return;
+        const saved = JSON.parse(savedRaw);
         marks = saved.marks || 1000;
         Object.assign(portfolio, saved.portfolio);
         updatePortfolio();
+      } catch (e) {
+        console.error("Failed to parse portfolio from localStorage", e);
+        localStorage.removeItem("fablePortfolio");
       }
     }
 


### PR DESCRIPTION
## Summary
- prevent crashes by adding updateDetailsPage, numeric price history, and safe portfolio loading
- implement full trading helpers in details script and correct marks display id
- add placeholder NPC and Archive pages to resolve broken navigation

## Testing
- `npx jshint details.js script.js portfolio.js` *(fails: 403 Forbidden – package download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a203e34e308324a67227cd849e03ce