### PR TITLE
Add Jest tests and enable CI test runs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
+    - run: npm install
     - run: npm test

--- a/__tests__/trade.test.js
+++ b/__tests__/trade.test.js
@@ -1,0 +1,26 @@
+const { calculateTrade } = require('../script');
+
+describe('calculateTrade', () => {
+  const security = { code: 'ABC', price: 100 };
+
+  test('handles buy when enough marks', () => {
+    const { success, marks, portfolio } = calculateTrade(1000, {}, security, 2, 'buy');
+    expect(success).toBe(true);
+    expect(marks).toBe(800);
+    expect(portfolio.ABC).toBe(2);
+  });
+
+  test('handles sell with sufficient holdings', () => {
+    const { success, marks, portfolio } = calculateTrade(500, { ABC: 5 }, security, 3, 'sell');
+    expect(success).toBe(true);
+    expect(marks).toBe(800);
+    expect(portfolio.ABC).toBe(2);
+  });
+
+  test('fails when funds insufficient', () => {
+    const { success, marks, portfolio } = calculateTrade(100, {}, security, 2, 'buy');
+    expect(success).toBe(false);
+    expect(marks).toBe(100);
+    expect(portfolio).toEqual({});
+  });
+});

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,11 @@
+const { calculateTotalCost, formatMarks } = require('../utils');
+
+describe('utils', () => {
+  test('calculateTotalCost multiplies quantity by price', () => {
+    expect(calculateTotalCost(3, 50)).toBe(150);
+  });
+
+  test('formatMarks formats number with currency symbol', () => {
+    expect(formatMarks(100)).toBe('₥100.00');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fable-market-exchange",
+  "version": "1.0.0",
+  "description": "📘 Fable Markets Exchange",
+  "main": "details.js",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,11 @@
+function calculateTotalCost(qty, price) {
+  return qty * price;
+}
+
+function formatMarks(amount) {
+  return `₥${Number(amount).toFixed(2)}`;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { calculateTotalCost, formatMarks };
+}


### PR DESCRIPTION
## Summary
- add utility helpers and pure trade calculator
- cover helpers and trade logic with Jest tests
- run tests in CI workflow

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e64193f08324877a869ef083d342