### PR TITLE
Move NPC activity log to dedicated page

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -12,7 +12,7 @@
     <nav>
       <a href="index.html">Exchange</a> |
       <a href="portfolio.html">Portfolio</a> |
-      <a href="npc.html">NPCs</a> |
+      <a href="npc.html">NPC Log</a> |
       <a href="archive.html" class="active">Archive</a>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <nav>
       <a href="index.html" class="active">Exchange</a> |
       <a href="portfolio.html">Portfolio</a> |
-      <a href="npc.html">NPCs</a> |
+      <a href="npc.html">NPC Log</a> |
       <a href="archive.html">Archive</a>
     </nav>
   </header>
@@ -40,11 +40,6 @@
       <h2>Your Portfolio</h2>
       <p>Available Funds: <span id="marksDisplay">₥0.00</span></p>
       <ul id="portfolioList"></ul>
-    </section>
-
-    <section id="npc">
-      <h2>NPC Activity</h2>
-      <ul id="npcLog"></ul>
     </section>
 
     <section id="news">

--- a/npc-log.js
+++ b/npc-log.js
@@ -1,0 +1,12 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const npcLog = document.getElementById("npcLog");
+  function render() {
+    const log = JSON.parse(localStorage.getItem("npcTradeLog")) || [];
+    npcLog.innerHTML = "";
+    log.slice().reverse().forEach(entry => {
+      npcLog.appendChild(Object.assign(document.createElement("li"), { textContent: entry }));
+    });
+  }
+  render();
+  setInterval(render, 5000);
+});

--- a/npc.html
+++ b/npc.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>NPCs - Fable Exchange</title>
+  <title>NPC Log - Fable Exchange</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -12,13 +12,14 @@
     <nav>
       <a href="index.html">Exchange</a> |
       <a href="portfolio.html">Portfolio</a> |
-      <a href="npc.html" class="active">NPCs</a> |
+      <a href="npc.html" class="active">NPC Log</a> |
       <a href="archive.html">Archive</a>
     </nav>
   </header>
   <main>
-    <h2>NPCs</h2>
-    <p>NPC directory coming soon.</p>
+    <h2>NPC Trade Log</h2>
+    <ul id="npcLog"></ul>
   </main>
+  <script src="npc-log.js"></script>
 </body>
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -12,7 +12,7 @@
     <h1>📊 Player Portfolio</h1>
     <nav>
       <a href="index.html">Exchange</a> |
-      <a href="npc.html">NPCs</a> |
+      <a href="npc.html">NPC Log</a> |
       <a href="archive.html">Archive</a> |
       <a href="portfolio.html" class="active">Portfolio</a>
     </nav>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const newsArchive = JSON.parse(localStorage.getItem("newsArchive")) || [];
     const npcProfiles = {};
     const topStories = [];
+    const npcTradeLog = JSON.parse(localStorage.getItem("npcTradeLog")) || [];
 
     const securities = generateSecurities();
     let selected = null;
@@ -42,7 +43,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const npcSelect = document.getElementById("npcSelect");
     const npcProfileOutput = document.getElementById("npcProfileOutput");
 
-    if (!dropdown || !marksDisplay || !newsTicker || !portfolioList || !npcLog || !archive || !detailsPanel || !tradeQtyInput || !filterSelect || !topStoriesBox || !npcSelect || !npcProfileOutput) {
+    if (!dropdown || !marksDisplay || !newsTicker || !portfolioList || !archive || !detailsPanel || !tradeQtyInput || !filterSelect || !topStoriesBox || !npcSelect || !npcProfileOutput) {
       throw new Error("Critical UI element missing. Check HTML structure.");
     }
 
@@ -277,10 +278,16 @@ document.addEventListener("DOMContentLoaded", () => {
       const action = Math.random() < 0.5 ? "buys" : "sells";
       const npc = npcProfiles[name];
       const msg = `🏦 ${name} ${action} ${qty} units of ${target.code}`;
+      const time = new Date().toLocaleTimeString();
+      const entry = `[${time}] ${msg}`;
 
-      npcLog.prepend(Object.assign(document.createElement("li"), { textContent: msg }));
+      if (npcLog) {
+        npcLog.prepend(Object.assign(document.createElement("li"), { textContent: entry }));
+      }
+      npcTradeLog.push(entry);
+      localStorage.setItem("npcTradeLog", JSON.stringify(npcTradeLog.slice(-100)));
       logEvent(msg);
-      npc.history.push(msg);
+      npc.history.push(entry);
 
       if (action === "buys") {
         npc.holdings[target.code] = (npc.holdings[target.code] || 0) + qty;


### PR DESCRIPTION
## Summary
- Remove NPC trade log from main exchange page and link to new NPC log page in navigation.
- Add standalone NPC log page with script that reads trade history from `localStorage`.
- Record NPC trades to `localStorage` for cross-page access and display.

## Testing
- `node --check script.js`
- `node --check npc-log.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae819638b08324a8c3d0baed7b4b01