### PR TITLE
refactor: centralize data and streamline updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,8 @@
     </section>
   </main>
 
+  <script src="securities.js"></script>
+  <script src="storage.js"></script>
   <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/npc-log.js
+++ b/npc-log.js
@@ -1,12 +1,27 @@
 document.addEventListener("DOMContentLoaded", () => {
   const npcLog = document.getElementById("npcLog");
-  function render() {
-    const log = JSON.parse(localStorage.getItem("npcTradeLog")) || [];
+
+  function render(log) {
     npcLog.innerHTML = "";
     log.slice().reverse().forEach(entry => {
       npcLog.appendChild(Object.assign(document.createElement("li"), { textContent: entry }));
     });
   }
-  render();
-  setInterval(render, 5000);
+
+  let cached = JSON.parse(localStorage.getItem("npcTradeLog")) || [];
+  render(cached);
+
+  window.addEventListener("storage", e => {
+    if (e.key === "npcTradeLog") {
+      const updated = JSON.parse(e.newValue || "[]");
+      if (updated.length < cached.length) {
+        render(updated);
+      } else {
+        updated.slice(cached.length).forEach(entry => {
+          npcLog.prepend(Object.assign(document.createElement("li"), { textContent: entry }));
+        });
+      }
+      cached = updated;
+    }
+  });
 });

--- a/portfolio.html
+++ b/portfolio.html
@@ -53,6 +53,8 @@
     </section>
   </main>
 
+  <script src="securities.js"></script>
+  <script src="storage.js"></script>
   <script src="portfolio.js"></script>
 </body>
 </html>

--- a/portfolio.js
+++ b/portfolio.js
@@ -7,45 +7,12 @@ document.addEventListener("DOMContentLoaded", () => {
   const tradeHistoryEl = document.getElementById("tradeHistory");
   const ctx = document.getElementById("allocationChart").getContext("2d");
 
-  const securities = generateSecurities();
-  const { portfolio, marks, tradeHistory } = loadPortfolio();
+  const securities = SECURITIES;
+  const { portfolio, marks, tradeHistory } = loadPortfolioData();
 
   renderPortfolio();
   renderTradeHistory();
   drawAllocationChart();
-
-  function generateSecurities() {
-    return [
-      { code: "WHT", name: "Wheat Futures", price: 120, sector: "Grain" },
-      { code: "OBL", name: "Oswald Bonds", price: 200, sector: "Infrastructure" },
-      { code: "FMR", name: "Fae Mirror Shards", price: 350, sector: "Magical" },
-      { code: "CNT", name: "Cattle Contracts", price: 160, sector: "Grain" },
-      { code: "BNS", name: "Beans Scrip", price: 95, sector: "Grain" },
-      { code: "CRN", name: "Corn Contracts", price: 110, sector: "Grain" },
-      { code: "GHM", name: "Golem Housing Mortgages", price: 280, sector: "Infrastructure" },
-      { code: "LLF", name: "Living Lumber Futures", price: 210, sector: "Magical" },
-      { code: "SLK", name: "Sunleaf Kettles", price: 75, sector: "Magical" },
-      { code: "BRK", name: "Barony Roadkeepers Bond", price: 180, sector: "Infrastructure" },
-      { code: "PRL", name: "Pearl Contracts", price: 260, sector: "Magical" },
-      { code: "SRL", name: "Salt Rail Shares", price: 190, sector: "Infrastructure" }
-    ];
-  }
-
-  function loadPortfolio() {
-    try {
-      const raw = localStorage.getItem("fablePortfolio");
-      const saved = raw ? JSON.parse(raw) : {};
-      return {
-        marks: saved.marks || 1000,
-        portfolio: saved.portfolio || {},
-        tradeHistory: saved.tradeHistory || []
-      };
-    } catch (e) {
-      console.error("Failed to parse portfolio from localStorage", e);
-      localStorage.removeItem("fablePortfolio");
-      return { marks: 1000, portfolio: {}, tradeHistory: [] };
-    }
-  }
 
   function formatMarks(val) {
     return `₥${Number(val).toLocaleString(undefined, { minimumFractionDigits: 2 })}`;

--- a/securities.js
+++ b/securities.js
@@ -1,0 +1,14 @@
+const SECURITIES = [
+  { code: "WHT", name: "Wheat Futures", price: 120, desc: "Grain commodity.", sector: "Grain", volatility: 0.03 },
+  { code: "OBL", name: "Oswald Bonds", price: 200, desc: "Infrastructure bond.", sector: "Infrastructure", volatility: 0.02 },
+  { code: "FMR", name: "Fae Mirror Shards", price: 350, desc: "Luxury magical good.", sector: "Magical", volatility: 0.08 },
+  { code: "CNT", name: "Cattle Contracts", price: 160, desc: "Livestock asset.", sector: "Grain", volatility: 0.025 },
+  { code: "BNS", name: "Beans Scrip", price: 95, desc: "Staple commodity.", sector: "Grain", volatility: 0.04 },
+  { code: "CRN", name: "Corn Contracts", price: 110, desc: "Food staple.", sector: "Grain", volatility: 0.035 },
+  { code: "GHM", name: "Golem Housing Mortgages", price: 280, desc: "Magical construction credit.", sector: "Infrastructure", volatility: 0.06 },
+  { code: "LLF", name: "Living Lumber Futures", price: 210, desc: "Fey-grown timber.", sector: "Magical", volatility: 0.05 },
+  { code: "SLK", name: "Sunleaf Kettles", price: 75, desc: "Alchemical ingredient.", sector: "Magical", volatility: 0.07 },
+  { code: "BRK", name: "Barony Roadkeepers Bond", price: 180, desc: "Civic infrastructure bond.", sector: "Infrastructure", volatility: 0.03 },
+  { code: "PRL", name: "Pearl Contracts", price: 260, desc: "Luxury marine goods.", sector: "Magical", volatility: 0.04 },
+  { code: "SRL", name: "Salt Rail Shares", price: 190, desc: "Transportation network.", sector: "Infrastructure", volatility: 0.05 }
+];

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,25 @@
+function loadPortfolioData() {
+  try {
+    const raw = localStorage.getItem("fablePortfolio");
+    const saved = raw ? JSON.parse(raw) : {};
+    const portfolio = {};
+    const savedPortfolio = saved.portfolio || {};
+    for (const code in savedPortfolio) {
+      const entry = savedPortfolio[code];
+      portfolio[code] = typeof entry === "number" ? { units: entry, avgCost: 0 } : entry;
+    }
+    return {
+      marks: saved.marks || 1000,
+      portfolio,
+      tradeHistory: saved.tradeHistory || []
+    };
+  } catch (e) {
+    console.error("Failed to parse portfolio from localStorage", e);
+    localStorage.removeItem("fablePortfolio");
+    return { marks: 1000, portfolio: {}, tradeHistory: [] };
+  }
+}
+
+function savePortfolioData(data) {
+  localStorage.setItem("fablePortfolio", JSON.stringify(data));
+}


### PR DESCRIPTION
## Summary
- centralize security definitions and portfolio storage helpers
- clean up trade flow and pause background simulations when hidden
- update NPC log to append entries via storage events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af29dbe5408324a7add91cd246c5ef