### PR TITLE
Add market summary top movers

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
   </header>
 
   <main>
+    <section id="marketSummary">
+      <h2>Market Summary</h2>
+      <div id="topGainers"></div>
+      <div id="topLosers"></div>
+    </section>
+
     <section id="exchange">
       <h2>Market Trading</h2>
       <label for="productDropdown">Select Security:</label>


### PR DESCRIPTION
## Summary
- Add `marketSummary` section to display top gainers and losers.
- Compute top movers from `SECURITIES` and refresh on load and each simulation tick.

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68af33c2ecfc83248f98c85c75abd25e