### PR TITLE
feat: show portfolio totals on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
     <section id="portfolio">
       <h2>Your Portfolio</h2>
       <p>Available Funds: <span id="marksDisplay">₥0.00</span></p>
+      <p>Total Value: <span id="totalValueDisplay">₥0.00</span></p>
+      <p>Profit/Loss: <span id="profitLossDisplay">₥0.00</span></p>
       <ul id="portfolioList"></ul>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -37,6 +37,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const dropdown = document.getElementById("productDropdown");
     const marksDisplay = document.getElementById("marksDisplay");
+    const totalValueDisplay = document.getElementById("totalValueDisplay");
+    const profitLossDisplay = document.getElementById("profitLossDisplay");
     const newsTicker = document.getElementById("newsTicker");
     const portfolioList = document.getElementById("portfolioList");
     const npcLog = document.getElementById("npcLog");
@@ -48,7 +50,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const npcSelect = document.getElementById("npcSelect");
     const npcProfileOutput = document.getElementById("npcProfileOutput");
 
-    if (!dropdown || !marksDisplay || !newsTicker || !portfolioList || !archive || !detailsPanel || !tradeQtyInput || !filterSelect || !topStoriesBox || !npcSelect || !npcProfileOutput) {
+    if (!dropdown || !marksDisplay || !totalValueDisplay || !profitLossDisplay || !newsTicker || !portfolioList || !archive || !detailsPanel || !tradeQtyInput || !filterSelect || !topStoriesBox || !npcSelect || !npcProfileOutput) {
       throw new Error("Critical UI element missing. Check HTML structure.");
     }
 
@@ -173,14 +175,22 @@ document.addEventListener("DOMContentLoaded", () => {
     function updatePortfolio() {
       marksDisplay.textContent = formatMarks(marks);
       portfolioList.innerHTML = Object.keys(portfolio).length === 0 ? "<li>None owned</li>" : "";
+      let totalValue = 0;
+      let totalPL = 0;
       for (const code in portfolio) {
         const sec = securities.find(s => s.code === code);
         const holding = portfolio[code];
         const val = sec.price * holding.units;
+        const pl = (sec.price - holding.avgCost) * holding.units;
+        totalValue += val;
+        totalPL += pl;
         const li = document.createElement("li");
         li.textContent = `${code}: ${holding.units} units (avg ${formatMarks(holding.avgCost)} ≈ ${formatMarks(val)})`;
         portfolioList.appendChild(li);
       }
+      totalValueDisplay.textContent = formatMarks(totalValue);
+      profitLossDisplay.textContent = `${totalPL >= 0 ? '+' : ''}${formatMarks(totalPL)}`;
+      profitLossDisplay.style.color = totalPL >= 0 ? "lime" : "crimson";
     }
 
     function savePortfolio() {


### PR DESCRIPTION
## Summary
- add total portfolio value and profit/loss display to homepage
- compute totals in `updatePortfolio()` using portfolio logic and color-code results

## Testing
- `node --check script.js && echo "script.js syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68af33c309ec8324868808d662924fe9