### PR TITLE
Provide offline canvas charts when Chart.js missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Fable Markets Exchange is a browser-based fantasy commodities simulation that models trading, NPC behaviors, market volatility, and price shifts within the magical economy of Fable.
 🔧 Features
 
-    📈 Real-time price charts (Chart.js)
+    📈 Real-time price charts (Chart.js with offline fallback)
 
     🧠 Simulated NPC investors (banks, trusts, guilds)
 

--- a/portfolio.js
+++ b/portfolio.js
@@ -58,31 +58,51 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  function drawAllocationChart() {
-    const labels = [];
-    const values = [];
-    const backgroundColors = [];
+    function drawAllocationChart() {
+      const labels = [];
+      const values = [];
+      const backgroundColors = [];
 
-    for (const code in portfolio) {
-      const sec = securities.find(s => s.code === code);
-      const holding = portfolio[code];
-      labels.push(code);
-      values.push(holding.units * sec.price);
-      backgroundColors.push(randomColor());
+      for (const code in portfolio) {
+        const sec = securities.find(s => s.code === code);
+        const holding = portfolio[code];
+        labels.push(code);
+        values.push(holding.units * sec.price);
+        backgroundColors.push(randomColor());
+      }
+
+      if (typeof Chart !== "undefined") {
+        new Chart(ctx, {
+          type: "pie",
+          data: { labels, datasets: [{ data: values, backgroundColor: backgroundColors }] },
+          options: { responsive: true, plugins: { legend: { position: "bottom" } } }
+        });
+      } else {
+        drawFallbackPieChart(document.getElementById("allocationChart"), values, backgroundColors);
+      }
     }
 
-    new Chart(ctx, {
-      type: "pie",
-      data: {
-        labels,
-        datasets: [{ data: values, backgroundColor: backgroundColors }]
-      },
-      options: {
-        responsive: true,
-        plugins: { legend: { position: "bottom" } }
-      }
-    });
-  }
+    // Very small pie chart drawer used when Chart.js isn't loaded
+    function drawFallbackPieChart(canvas, values, colors) {
+      const ctx2 = canvas.getContext("2d");
+      const size = Math.min(canvas.clientWidth || 300, 300);
+      canvas.width = canvas.height = size;
+      const total = values.reduce((a, b) => a + b, 0) || 1;
+      let start = 0;
+      const cx = size / 2;
+      const cy = size / 2;
+      const radius = size / 2 - 5;
+      values.forEach((v, i) => {
+        const slice = (v / total) * Math.PI * 2;
+        ctx2.beginPath();
+        ctx2.moveTo(cx, cy);
+        ctx2.fillStyle = colors[i];
+        ctx2.arc(cx, cy, radius, start, start + slice);
+        ctx2.closePath();
+        ctx2.fill();
+        start += slice;
+      });
+    }
 
   function randomColor() {
     const h = Math.floor(Math.random() * 360);

--- a/script.js
+++ b/script.js
@@ -101,25 +101,65 @@ document.addEventListener("DOMContentLoaded", () => {
       document.getElementById("volatilityData").textContent = `Volatility: ${security.volatility}`;
     }
 
-    function drawChart(security) {
-      const chartCanvas = document.getElementById("priceChart");
-      if (!chartCanvas || !chartCanvas.getContext) return;
-      const ctx = chartCanvas.getContext("2d");
-      if (priceChart) priceChart.destroy();
-      const history = generatePriceHistory(security.price, security.volatility);
-      priceChart = new Chart(ctx, {
-        type: "line",
-        data: {
-          labels: history.map((_, i) => `Day ${i + 1}`),
-          datasets: [{ label: `${security.code} Price History`, data: history, borderColor: "#7ad9ff", backgroundColor: "rgba(122, 217, 255, 0.1)", fill: true }]
-        },
-        options: {
-          responsive: true,
-          plugins: { legend: { display: true } },
-          scales: { x: { display: true }, y: { beginAtZero: false } }
+      function drawChart(security) {
+        const chartCanvas = document.getElementById("priceChart");
+        if (!chartCanvas || !chartCanvas.getContext) return;
+        const ctx = chartCanvas.getContext("2d");
+        const history = generatePriceHistory(security.price, security.volatility);
+
+        // Prefer Chart.js if available; otherwise draw a simple canvas chart.
+        if (typeof Chart !== "undefined") {
+          if (priceChart) priceChart.destroy();
+          priceChart = new Chart(ctx, {
+            type: "line",
+            data: {
+              labels: history.map((_, i) => `Day ${i + 1}`),
+              datasets: [{ label: `${security.code} Price History`, data: history, borderColor: "#7ad9ff", backgroundColor:"rgba(122, 217, 255, 0.1)", fill: true }]
+            },
+            options: {
+              responsive: true,
+              plugins: { legend: { display: true } },
+              scales: { x: { display: true }, y: { beginAtZero: false } }
+            }
+          });
+        } else {
+          drawFallbackLineChart(chartCanvas, history);
         }
-      });
-    }
+      }
+
+      // Basic line chart renderer used when Chart.js is not loaded
+      function drawFallbackLineChart(canvas, data) {
+        const ctx = canvas.getContext("2d");
+        const width = canvas.clientWidth || 600;
+        const height = 300;
+        canvas.width = width;
+        canvas.height = height;
+        ctx.clearRect(0, 0, width, height);
+
+        const padding = 40;
+        const min = Math.min(...data);
+        const max = Math.max(...data);
+        const xStep = (width - padding * 2) / (data.length - 1);
+        const yScale = (height - padding * 2) / (max - min || 1);
+
+        ctx.strokeStyle = "#555";
+        ctx.beginPath();
+        ctx.moveTo(padding, padding);
+        ctx.lineTo(padding, height - padding);
+        ctx.lineTo(width - padding, height - padding);
+        ctx.stroke();
+
+        ctx.strokeStyle = "#7ad9ff";
+        ctx.beginPath();
+        data.forEach((v, i) => {
+          const x = padding + i * xStep;
+          const y = height - padding - (v - min) * yScale;
+          if (i === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+      }
+
 
     function generatePriceHistory(base, vol) {
       const history = [];


### PR DESCRIPTION
## Summary
- add manual canvas line chart fallback for price history when Chart.js fails to load
- add pie chart fallback for portfolio allocation
- document offline chart capability in README

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`
- `node --check portfolio.js`


------
https://chatgpt.com/codex/tasks/task_e_68af6fa4088c8324b3f1c9d2f97ce7fe