### PR TITLE
Add Node-based storage tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "fable-market-exchange",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fable-market-exchange",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fable-market-exchange",
+  "version": "1.0.0",
+  "description": "📘 Fable Markets Exchange",
+  "main": "npc-log.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/storage.js
+++ b/storage.js
@@ -23,3 +23,7 @@ function loadPortfolioData() {
 function savePortfolioData(data) {
   localStorage.setItem("fablePortfolio", JSON.stringify(data));
 }
+
+if (typeof module !== "undefined") {
+  module.exports = { loadPortfolioData, savePortfolioData };
+}

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { loadPortfolioData, savePortfolioData } = require('../storage.js');
+
+class LocalStorageMock {
+  constructor() {
+    this.store = {};
+  }
+  clear() {
+    this.store = {};
+  }
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  }
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+  removeItem(key) {
+    delete this.store[key];
+  }
+}
+
+global.localStorage = new LocalStorageMock();
+
+test.beforeEach(() => {
+  global.localStorage.clear();
+});
+
+test('loadPortfolioData returns defaults when storage empty', () => {
+  const data = loadPortfolioData();
+  assert.deepEqual(data, { marks: 1000, portfolio: {}, tradeHistory: [] });
+});
+
+test('loadPortfolioData converts numeric portfolio entries', () => {
+  localStorage.setItem('fablePortfolio', JSON.stringify({
+    marks: 1200,
+    portfolio: { WHT: 5 },
+    tradeHistory: []
+  }));
+  const data = loadPortfolioData();
+  assert.deepEqual(data.portfolio, { WHT: { units: 5, avgCost: 0 } });
+  assert.strictEqual(data.marks, 1200);
+});
+
+test('savePortfolioData writes data to localStorage', () => {
+  const payload = { marks: 500, portfolio: { WHT: { units: 2, avgCost: 100 } }, tradeHistory: ['a'] };
+  savePortfolioData(payload);
+  const raw = localStorage.getItem('fablePortfolio');
+  assert.ok(raw);
+  const parsed = JSON.parse(raw);
+  assert.deepEqual(parsed, payload);
+});
+
+test('loadPortfolioData handles invalid JSON', () => {
+  localStorage.setItem('fablePortfolio', '{bad json');
+  const originalError = console.error;
+  console.error = () => {};
+  const data = loadPortfolioData();
+  console.error = originalError;
+  assert.deepEqual(data, { marks: 1000, portfolio: {}, tradeHistory: [] });
+  assert.strictEqual(localStorage.getItem('fablePortfolio'), null);
+});


### PR DESCRIPTION
## Summary
- add Node test runner configuration
- export storage functions for testing and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8814b7c483248a97891ffd496e7a