### PR TITLE
Add exchange index page listing all securities

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Fable Markets Exchange is a browser-based fantasy commodities simulation that mo
 /project-root
 │
 ├── index.html          # Main trading dashboard
+├── exchange-index.html # List of all securities
 ├── style.css           # Dark mode layout & UI
 ├── script.js           # Core simulation logic
 ├── README.md           # You're reading it
@@ -30,7 +31,7 @@ Fable Markets Exchange is a browser-based fantasy commodities simulation that mo
 
     Clone or download the repo
 
-    Open index.html in a browser
+    Open index.html for trading or exchange-index.html to view all securities
 
     Interact with the market (select a security, buy/sell, observe price shifts)
 

--- a/archive.html
+++ b/archive.html
@@ -13,6 +13,7 @@
       <a href="dashboard.html">Dashboard</a> |
       <a href="portfolio.html">Portfolio</a> |
       <a href="index.html">Exchange</a> |
+      <a href="exchange-index.html">Index</a> |
       <a href="archive.html" class="active">Archive</a> |
       <a href="civic-report.html">The Civic Report</a>
     </nav>

--- a/civic-report.html
+++ b/civic-report.html
@@ -13,6 +13,7 @@
       <a href="dashboard.html">Dashboard</a> |
       <a href="portfolio.html">Portfolio</a> |
       <a href="index.html">Exchange</a> |
+      <a href="exchange-index.html">Index</a> |
       <a href="archive.html">Archive</a> |
       <a href="civic-report.html" class="active">The Civic Report</a>
     </nav>

--- a/dashboard.html
+++ b/dashboard.html
@@ -13,6 +13,7 @@
       <a href="dashboard.html" class="active">Dashboard</a> |
       <a href="portfolio.html">Portfolio</a> |
       <a href="index.html">Exchange</a> |
+      <a href="exchange-index.html">Index</a> |
       <a href="archive.html">Archive</a> |
       <a href="civic-report.html">The Civic Report</a>
     </nav>

--- a/exchange-index.html
+++ b/exchange-index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Exchange Index</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>📊 Exchange Index</h1>
+    <nav>
+      <a href="dashboard.html">Dashboard</a> |
+      <a href="portfolio.html">Portfolio</a> |
+      <a href="index.html">Exchange</a> |
+      <a href="exchange-index.html" class="active">Index</a> |
+      <a href="archive.html">Archive</a> |
+      <a href="civic-report.html">The Civic Report</a>
+    </nav>
+  </header>
+  <main>
+    <section id="indexSection">
+      <h2>All Securities</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Code</th>
+            <th>Name</th>
+            <th>Price</th>
+            <th>Volatility</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody id="securitiesTable"></tbody>
+      </table>
+    </section>
+  </main>
+  <script src="securities.js"></script>
+  <script src="exchange-index.js"></script>
+</body>
+</html>
+

--- a/exchange-index.js
+++ b/exchange-index.js
@@ -1,0 +1,23 @@
+// exchange-index.js - render all securities in a table
+
+document.addEventListener("DOMContentLoaded", () => {
+  const tableBody = document.getElementById("securitiesTable");
+  if (!tableBody) return;
+
+  function formatMarks(val) {
+    return `₥${Number(val).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+
+  SECURITIES.forEach(sec => {
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${sec.code}</td>
+      <td>${sec.name}</td>
+      <td>${formatMarks(sec.price)}</td>
+      <td>${sec.volatility}</td>
+      <td>${sec.desc}</td>
+    `;
+    tableBody.appendChild(row);
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -11,13 +11,14 @@
   <header>
     <h1>📈 Fable Market Exchange</h1>
     <nav>
-      <a href="dashboard.html">Dashboard</a> |
-      <a href="portfolio.html">Portfolio</a> |
-      <a href="index.html" class="active">Exchange</a> |
-      <a href="archive.html">Archive</a> |
-      <a href="civic-report.html">The Civic Report</a>
-    </nav>
-  </header>
+        <a href="dashboard.html">Dashboard</a> |
+        <a href="portfolio.html">Portfolio</a> |
+        <a href="index.html" class="active">Exchange</a> |
+        <a href="exchange-index.html">Index</a> |
+        <a href="archive.html">Archive</a> |
+        <a href="civic-report.html">The Civic Report</a>
+      </nav>
+    </header>
 
   <main>
     <section id="marketSummary">

--- a/npc.html
+++ b/npc.html
@@ -13,6 +13,7 @@
       <a href="dashboard.html">Dashboard</a> |
       <a href="portfolio.html">Portfolio</a> |
       <a href="index.html">Exchange</a> |
+      <a href="exchange-index.html">Index</a> |
       <a href="archive.html">Archive</a> |
       <a href="civic-report.html">The Civic Report</a>
     </nav>

--- a/portfolio.html
+++ b/portfolio.html
@@ -14,6 +14,7 @@
       <a href="dashboard.html">Dashboard</a> |
       <a href="portfolio.html" class="active">Portfolio</a> |
       <a href="index.html">Exchange</a> |
+      <a href="exchange-index.html">Index</a> |
       <a href="archive.html">Archive</a> |
       <a href="civic-report.html">The Civic Report</a>
     </nav>


### PR DESCRIPTION
## Summary
- Create `exchange-index.html` displaying all securities in a table
- Populate the new index via `exchange-index.js`
- Link the index page in site navigation and update README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b633f2aa608324ab549f234d5f2b39