### PR TITLE
Populate placeholder pages

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -20,7 +20,8 @@
   </header>
   <main>
     <h2>Archive</h2>
-    <p>Historical news archive coming soon.</p>
+    <ul id="archiveList"></ul>
   </main>
+  <script src="archive.js"></script>
 </body>
 </html>

--- a/archive.js
+++ b/archive.js
@@ -1,0 +1,18 @@
+// archive.js — renders saved news events
+
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('archiveList');
+  if (!list) return;
+
+  const archive = JSON.parse(localStorage.getItem('newsArchive')) || [];
+  if (archive.length === 0) {
+    list.innerHTML = '<li>No news events recorded yet.</li>';
+    return;
+  }
+
+  archive.slice().reverse().forEach(entry => {
+    const li = document.createElement('li');
+    li.textContent = entry;
+    list.appendChild(li);
+  });
+});

--- a/civic-report.html
+++ b/civic-report.html
@@ -20,7 +20,16 @@
   </header>
   <main>
     <h2>Latest Civic News</h2>
-    <p>Reports coming soon.</p>
+    <article>
+      <h3>Markets Support Local Causes</h3>
+      <p>The exchange's recent surge in trading has helped fund new community
+        projects across the kingdom.</p>
+    </article>
+    <article>
+      <h3>Banking Guild Announces Scholarship</h3>
+      <p>The Royal Frog Bank has pledged a scholarship program for aspiring
+        traders, fostering the next generation of market wizards.</p>
+    </article>
   </main>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -20,7 +20,15 @@
   </header>
   <main>
     <h2>Dashboard</h2>
-    <p>Overview coming soon.</p>
+    <div id="dashboardSummary"></div>
+    <p>
+      Use the dashboard to get a quick snapshot of your trading activity.
+      Visit the <a href="portfolio.html">portfolio</a> page for detailed
+      holdings or head to the <a href="index.html">exchange</a> to place a
+      trade.
+    </p>
   </main>
+  <script src="storage.js"></script>
+  <script src="dashboard.js"></script>
 </body>
 </html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,18 @@
+// dashboard.js — simple portfolio summary on dashboard page
+
+document.addEventListener('DOMContentLoaded', () => {
+  const summary = document.getElementById('dashboardSummary');
+  if (!summary) return;
+
+  try {
+    const { marks, portfolio } = loadPortfolioData();
+    const codes = Object.keys(portfolio);
+    const holdings = codes.length ? codes.join(', ') : 'none yet';
+    summary.innerHTML = `
+      <p>Available Funds: <strong>₥${marks.toFixed(2)}</strong></p>
+      <p>Current Holdings: <em>${holdings}</em></p>
+    `;
+  } catch (e) {
+    summary.textContent = 'Unable to load portfolio data.';
+  }
+});


### PR DESCRIPTION
## Summary
- Flesh out dashboard page with basic portfolio summary using new `dashboard.js`
- Replace archive placeholder with list of stored news events and `archive.js`
- Fill Civic Report with sample articles highlighting community impacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63ceac83c83248d5ef1e6c7646170