### PR TITLE
Link Civic Report to external site

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -15,7 +15,7 @@
       <a href="index.html">Exchange</a> |
       <a href="exchange-index.html">Index</a> |
       <a href="archive.html" class="active">Archive</a> |
-      <a href="civic-report.html">The Civic Report</a>
+      <a href="https://rpginquisitor.com/the-civic-report/" target="_blank" rel="noopener noreferrer">The Civic Report</a>
     </nav>
   </header>
   <main>

--- a/civic-report.html
+++ b/civic-report.html
@@ -2,34 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="refresh" content="0; url=https://rpginquisitor.com/the-civic-report/" />
   <title>The Civic Report - Fable Exchange</title>
-  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header>
-    <h1>📰 The Civic Report</h1>
-    <nav>
-      <a href="dashboard.html">Dashboard</a> |
-      <a href="portfolio.html">Portfolio</a> |
-      <a href="index.html">Exchange</a> |
-      <a href="exchange-index.html">Index</a> |
-      <a href="archive.html">Archive</a> |
-      <a href="civic-report.html" class="active">The Civic Report</a>
-    </nav>
-  </header>
-  <main>
-    <h2>Latest Civic News</h2>
-    <article>
-      <h3>Markets Support Local Causes</h3>
-      <p>The exchange's recent surge in trading has helped fund new community
-        projects across the kingdom.</p>
-    </article>
-    <article>
-      <h3>Banking Guild Announces Scholarship</h3>
-      <p>The Royal Frog Bank has pledged a scholarship program for aspiring
-        traders, fostering the next generation of market wizards.</p>
-    </article>
-  </main>
+  <p>Redirecting to <a href="https://rpginquisitor.com/the-civic-report/">The Civic Report</a>...</p>
 </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -15,7 +15,7 @@
       <a href="index.html">Exchange</a> |
       <a href="exchange-index.html">Index</a> |
       <a href="archive.html">Archive</a> |
-      <a href="civic-report.html">The Civic Report</a>
+      <a href="https://rpginquisitor.com/the-civic-report/" target="_blank" rel="noopener noreferrer">The Civic Report</a>
     </nav>
   </header>
   <main>

--- a/exchange-index.html
+++ b/exchange-index.html
@@ -15,7 +15,7 @@
       <a href="index.html">Exchange</a> |
       <a href="exchange-index.html" class="active">Index</a> |
       <a href="archive.html">Archive</a> |
-      <a href="civic-report.html">The Civic Report</a>
+      <a href="https://rpginquisitor.com/the-civic-report/" target="_blank" rel="noopener noreferrer">The Civic Report</a>
     </nav>
   </header>
   <main>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <a href="index.html" class="active">Exchange</a> |
         <a href="exchange-index.html">Index</a> |
         <a href="archive.html">Archive</a> |
-        <a href="civic-report.html">The Civic Report</a>
+        <a href="https://rpginquisitor.com/the-civic-report/" target="_blank" rel="noopener noreferrer">The Civic Report</a>
       </nav>
     </header>
 

--- a/npc.html
+++ b/npc.html
@@ -15,7 +15,7 @@
       <a href="index.html">Exchange</a> |
       <a href="exchange-index.html">Index</a> |
       <a href="archive.html">Archive</a> |
-      <a href="civic-report.html">The Civic Report</a>
+      <a href="https://rpginquisitor.com/the-civic-report/" target="_blank" rel="noopener noreferrer">The Civic Report</a>
     </nav>
   </header>
   <main>

--- a/portfolio.html
+++ b/portfolio.html
@@ -16,7 +16,7 @@
       <a href="index.html">Exchange</a> |
       <a href="exchange-index.html">Index</a> |
       <a href="archive.html">Archive</a> |
-      <a href="civic-report.html">The Civic Report</a>
+      <a href="https://rpginquisitor.com/the-civic-report/" target="_blank" rel="noopener noreferrer">The Civic Report</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- Point all "Civic Report" navigation links to the external report on rpginquisitor.com
- Replace local civic-report page with a redirect to the external report

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63ff22f7c832480de31f3e89466a5