### PR TITLE
Refactor dashboard summary DOM construction

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -8,10 +8,24 @@ document.addEventListener('DOMContentLoaded', () => {
     const { marks, portfolio } = loadPortfolioData();
     const codes = Object.keys(portfolio);
     const holdings = codes.length ? codes.join(', ') : 'none yet';
-    summary.innerHTML = `
-      <p>Available Funds: <strong>₥${marks.toFixed(2)}</strong></p>
-      <p>Current Holdings: <em>${holdings}</em></p>
-    `;
+    const fragment = document.createDocumentFragment();
+
+    const fundsP = document.createElement('p');
+    fundsP.textContent = 'Available Funds: ';
+    const marksStrong = document.createElement('strong');
+    marksStrong.textContent = `₥${marks.toFixed(2)}`;
+    fundsP.appendChild(marksStrong);
+
+    const holdingsP = document.createElement('p');
+    holdingsP.textContent = 'Current Holdings: ';
+    const holdingsEm = document.createElement('em');
+    holdingsEm.textContent = holdings;
+    holdingsP.appendChild(holdingsEm);
+
+    fragment.append(fundsP, holdingsP);
+
+    summary.textContent = '';
+    summary.appendChild(fragment);
   } catch (e) {
     summary.textContent = 'Unable to load portfolio data.';
   }


### PR DESCRIPTION
## Summary
- Build dashboard summary with DOM nodes instead of innerHTML
- Use `DocumentFragment` to minimize reflows and avoid `innerHTML`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ec7b14fc83248d1d1da7ebe76481