### PR TITLE
feat(storage): cache portfolio data

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -1,4 +1,9 @@
+let cachedData;
+
 function loadPortfolioData() {
+  if (cachedData) {
+    return cachedData;
+  }
   try {
     const raw = localStorage.getItem("fablePortfolio");
     const saved = raw ? JSON.parse(raw) : {};
@@ -8,20 +13,23 @@ function loadPortfolioData() {
       const entry = savedPortfolio[code];
       portfolio[code] = typeof entry === "number" ? { units: entry, avgCost: 0 } : entry;
     }
-    return {
+    cachedData = {
       marks: saved.marks || 1000,
       portfolio,
       tradeHistory: saved.tradeHistory || []
     };
+    return cachedData;
   } catch (e) {
     console.error("Failed to parse portfolio from localStorage", e);
     localStorage.removeItem("fablePortfolio");
-    return { marks: 1000, portfolio: {}, tradeHistory: [] };
+    cachedData = { marks: 1000, portfolio: {}, tradeHistory: [] };
+    return cachedData;
   }
 }
 
 function savePortfolioData(data) {
   localStorage.setItem("fablePortfolio", JSON.stringify(data));
+  cachedData = data;
 }
 
 if (typeof module !== "undefined") {


### PR DESCRIPTION
## Summary
- cache portfolio data in storage.js and reuse until save
- update savePortfolioData to refresh cache after writes
- adjust tests to clear cache each run and add caching behavior test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ec7c75488324af3ce529bc2e8ae4