### PR TITLE
Expand news ticker and show prices

### DIFF
--- a/script.js
+++ b/script.js
@@ -171,14 +171,14 @@ document.addEventListener("DOMContentLoaded", () => {
         const newUnits = holding.units + qty;
         holding.avgCost = ((holding.avgCost * holding.units) + total) / newUnits;
         holding.units = newUnits;
-        logEvent(`🏦 ✅ Bought ${qty} ${key} for ${formatMarks(total)}`);
+        logEvent(`🏦 ✅ Bought ${qty} ${key} at ${formatMarks(selected.price)} each for ${formatMarks(total)}`);
       tradeHistory.push(`[${time}] Bought ${qty} ${key} at ${formatMarks(selected.price)}`);
     } else if (type === "sell" && portfolio[key] && portfolio[key].units >= qty) {
       marks += total;
       const holding = portfolio[key];
       holding.units -= qty;
       if (holding.units === 0) delete portfolio[key];
-      logEvent(`🏦 🪙 Sold ${qty} ${key} for ${formatMarks(total)}`);
+      logEvent(`🏦 🪙 Sold ${qty} ${key} at ${formatMarks(selected.price)} each for ${formatMarks(total)}`);
       tradeHistory.push(`[${time}] Sold ${qty} ${key} at ${formatMarks(selected.price)}`);
     } else {
       logEvent(`🏦 ⚠️ Trade failed.`);
@@ -297,7 +297,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const qty = Math.floor(Math.random() * 20 + 1);
       const action = Math.random() < 0.5 ? "buys" : "sells";
       const npc = npcProfiles[name];
-      const msg = `🏦 ${name} ${action} ${qty} units of ${target.code}`;
+      const msg = `🏦 ${name} ${action} ${qty} units of ${target.code} at ${formatMarks(target.price)}`;
       const time = new Date().toLocaleTimeString();
       const entry = `[${time}] ${msg}`;
 

--- a/style.css
+++ b/style.css
@@ -72,8 +72,8 @@ button:hover {
   font-family: monospace;
   background-color: #1e1e1e;
   color: #00ffc8;
-  padding: 10px;
-  font-size: 14px;
+  padding: 15px;
+  font-size: 18px;
   overflow: hidden;
   border-bottom: 1px solid #333;
   position: sticky;


### PR DESCRIPTION
## Summary
- Enlarge scrolling news ticker for better visibility.
- Include per-unit prices in user and NPC trade news entries.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7c7eeebf0832492b70015e5dfbd9f