### PR TITLE
feat: show security prices in ticker

### DIFF
--- a/news-ticker.js
+++ b/news-ticker.js
@@ -4,17 +4,30 @@ document.addEventListener('DOMContentLoaded', () => {
   const ticker = document.getElementById('newsContent');
   if (!ticker) return;
 
-  const archive = JSON.parse(localStorage.getItem('newsArchive')) || [];
-  if (archive.length === 0) {
-    ticker.textContent = 'No news yet';
-    return;
+  function formatMarks(amount) {
+    return `₥${Number(amount).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
   }
 
-  const content = archive.join('  |  ');
-  ticker.textContent = content + '  |  ' + content;
+  function renderTicker() {
+    const archive = JSON.parse(localStorage.getItem('newsArchive')) || [];
+    const prices = (JSON.parse(localStorage.getItem('securitiesData')) || []).map(s => {
+      const change = s.basePrice ? ((s.price - s.basePrice) / s.basePrice) * 100 : 0;
+      return `${s.code} ${formatMarks(s.price)} (${change.toFixed(2)}%)`;
+    });
+    const items = [...prices, ...archive];
+    if (items.length === 0) {
+      ticker.textContent = 'No news yet';
+      return;
+    }
+    const content = items.join('  |  ');
+    ticker.textContent = content + '  |  ' + content;
 
-  ticker.style.animation = 'none';
-  void ticker.offsetWidth;
-  ticker.style.animation = '';
-  ticker.style.animation = 'ticker 30s linear infinite';
+    ticker.style.animation = 'none';
+    void ticker.offsetWidth;
+    ticker.style.animation = '';
+    ticker.style.animation = 'ticker 30s linear infinite';
+  }
+
+  renderTicker();
+  setInterval(renderTicker, 15000);
 });

--- a/script.js
+++ b/script.js
@@ -18,6 +18,10 @@ document.addEventListener("DOMContentLoaded", () => {
     const npcTradeLog = JSON.parse(localStorage.getItem("npcTradeLog")) || [];
 
     const securities = SECURITIES.map(sec => ({ ...sec, basePrice: sec.price }));
+    function storeSecurities() {
+      localStorage.setItem("securitiesData", JSON.stringify(securities));
+    }
+    storeSecurities();
     let selected = null;
     let priceChart = null;
 
@@ -326,6 +330,7 @@ document.addEventListener("DOMContentLoaded", () => {
         updateStats(target);
         updateMarketSummary();
       }
+      storeSecurities();
     }
 
     // Initial load


### PR DESCRIPTION
## Summary
- display each security's current price and percent change in the persistent news ticker
- persist security data in localStorage so ticker stays updated across pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7d6caa7048324aee80512eb2cd621